### PR TITLE
Add generated and documentation files to gitattribute

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -200,3 +200,10 @@ Procfile          text
 
 # Ignore files (like .npmignore or .gitignore)
 *.*ignore         text
+
+# Project specific
+tap-snapshots/**  linguist-generated
+pnpm-lock.yaml    linguist-generated
+.changeset/**     linguist-documentation
+.github/**        linguist-documentation
+scripts/**.js     linguist-language=ts


### PR DESCRIPTION
This fixes the problem which projects are considered as “JavaScript” instead of
the proper TypeScript.
