### PR TITLE
Replace cron schedules with the alternative

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -31,7 +31,7 @@
     "addLabels": [
       "renovate/lockfile"
     ],
-    "schedule": "* 12 * * 4",
+    "schedule": "at 12am on thursday",
     "automerge": true
   },
   "npm": {
@@ -108,7 +108,7 @@
       "matchManagers": [
         "github-actions"
       ],
-      "schedule": "* 12 * * 4",
+      "schedule": "at 12am on thursday",
       "automerge": false
     }
   ]


### PR DESCRIPTION
Allegedly, these were not allowed as per `renovate-config-validator`.
