### PR TITLE
Disable pnpm v6.28 embeded readme

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+embed-readme=false


### PR DESCRIPTION
This should be removed in v7 when it is the default.